### PR TITLE
Fixes to run gorump on XEN

### DIFF
--- a/examples/hello_world/Makefile
+++ b/examples/hello_world/Makefile
@@ -1,4 +1,5 @@
 all: hello.bin
+xen: hello-xen.bin
 
 %.a: %.go
 	CC=x86_64-rumprun-netbsd-gcc CGO_ENABLED=1 GOOS=rumprun ../../go/bin/go build -buildmode=c-archive -v -a -x $<
@@ -9,5 +10,8 @@ all: hello.bin
 %.bin: %.pseudo
 	rumprun-bake hw_virtio $@ $<
 
+%-xen.bin: %.pseudo
+	rumprun-bake xen_pv $@ $<
+
 clean:
-	rm -f hello.a hello.h hello hello.bin
+	rm -f hello*.a hello*.h hello hello-xen hello*.bin 

--- a/examples/hello_world/hello.c
+++ b/examples/hello_world/hello.c
@@ -1,5 +1,6 @@
 int kludge_argc = 1;
 char *kludge_argv[] = { "kludge", "argv" };
+char *kludge_env = "";
 
 int
 main()

--- a/examples/httpd/Makefile
+++ b/examples/httpd/Makefile
@@ -1,4 +1,5 @@
 all: httpd.bin
+xen: httpd-xen.bin
 
 %.a: %.go
 	CC=x86_64-rumprun-netbsd-gcc CGO_ENABLED=1 GOOS=rumprun ../../go/bin/go build -buildmode=c-archive -v -a -x $<
@@ -9,5 +10,8 @@ all: httpd.bin
 %.bin: %.pseudo
 	rumprun-bake hw_virtio $@ $<
 
+%-xen.bin: %.pseudo
+	rumprun-bake xen_pv $@ $<
+
 clean:
-	rm -f httpd.a httpd.h httpd httpd.bin
+	rm -f httpd*.a httpd*.h httpd httpd-xen httpd*.bin

--- a/examples/httpd/httpd.c
+++ b/examples/httpd/httpd.c
@@ -1,5 +1,6 @@
 int kludge_argc = 1;
 char *kludge_argv[] = { "foo", 0 };
+char *kludge_env = "";
 
 int
 main()

--- a/examples/multiple_go/Makefile
+++ b/examples/multiple_go/Makefile
@@ -1,4 +1,5 @@
 all: hello.bin
+xen: hello-xen.bin
 
 %.a: %.go
 	CC=x86_64-rumprun-netbsd-gcc CGO_ENABLED=1 GOOS=rumprun ../../go/bin/go build -buildmode=c-archive -v -a -x hello.go another.go
@@ -9,5 +10,8 @@ all: hello.bin
 %.bin: %.pseudo
 	rumprun-bake hw_virtio $@ $<
 
+%-xen.bin: %.pseudo
+	rumprun-bake xen_pv $@ $<
+
 clean:
-	rm -f hello.a hello.h hello hello.bin another.a another.h
+	rm -f hello*.a hello*.h hello hello-xen hello*.bin another*.a another*.h

--- a/examples/multiple_go/hello.c
+++ b/examples/multiple_go/hello.c
@@ -1,5 +1,6 @@
 int kludge_argc = 1;
 char *kludge_argv[] = { "kludge", "argv" };
+char *kludge_env = "";
 
 int
 main()

--- a/examples/nanomsq/nanomsg.c
+++ b/examples/nanomsq/nanomsg.c
@@ -1,5 +1,6 @@
 int kludge_argc = 1;
 char *kludge_argv[] = { "kludge", "argv" };
+char *kludge_env = "";
 
 int
 main()


### PR DESCRIPTION
Hi

as discussed in the issue  #22, this contains:
- fix to run gorump on XEN (extending stack to include an empty `envp`)
- updated README a bit to contain more up-to-date instructions (reran whole process, works)
- updated README with instructions for running on XEN (networking etc.)
- updated Makefiles of examples to include `make xen` which creates `something-xen.bin` 

Cheers
M
