### PR TITLE
zero out parts in the stack that are not zeroed in call to kevent

### DIFF
--- a/go1.5/src/runtime/sys_rumprun_amd64.s
+++ b/go1.5/src/runtime/sys_rumprun_amd64.s
@@ -327,6 +327,9 @@ TEXT runtime·kevent(SB),NOSPLIT,$16
 	MOVQ	$435, DI		// kevent
 	MOVQ	SP, SI			// args
 	ADDQ	$0x18, SI		// args
+	MOVL	$0, 0x04(SI)
+	MOVL	$0, 0x14(SI)
+	MOVL	$0, 0x24(SI)
 	MOVQ	$0, DX			// dlen -- ignored
 	MOVQ	SP, CX			// retval
 	LEAQ	rump_syscall(SB), AX


### PR DESCRIPTION
Fixes issue #35
